### PR TITLE
Fix: Watcher events for state files and sub-dirs

### DIFF
--- a/tests/unit/sync.spec.ts
+++ b/tests/unit/sync.spec.ts
@@ -102,7 +102,10 @@ describe("sync command – latest remote-only implementation", () => {
 
     (swarm.readFeedIndex as jest.Mock).mockResolvedValueOnce(0n);
     (swarm.listRemoteFilesMap as jest.Mock).mockResolvedValueOnce({ "b.txt": "refB" });
-    (swarm.downloadRemoteFile as jest.Mock).mockResolvedValueOnce(Buffer.from("old"));
+    (swarm.downloadRemoteFile as jest.Mock)
+      .mockResolvedValueOnce(Buffer.from("old"))
+      .mockResolvedValueOnce(Buffer.from("old"));
+    
 
     const REMOVED_REF = "c".repeat(64);
     const NEW_REF     = "d".repeat(64);


### PR DESCRIPTION
🔖 Title
Exclude Swarm config & state files from watch triggers

📝 Description
This patch prevents our file‐watcher from endlessly retriggering on its own metadata updates by:

Ignoring internal JSON files
• Adds ignored: ["**/.swarm-sync.json", "**/.swarm-sync-state.json"] to the chokidar watcher so changes to those files won’t fire “add/change/unlink” events.

Preserving nested folder depth
• Keeps depth: Infinity so true user-level folder changes are still captured.

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-471

🧪 How Has This Been Tested?
✅ Manually tested with a mocked Bee client

✅ Checklist
✅ My code follows the project’s style guide
✅ I have performed a self-review of my code
✅ I have commented my code where necessary
✅ I have added tests that prove my fix/feature works
✅ All new and existing tests pass locally